### PR TITLE
Fix ocad2image command bugs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { ocadToGeoJson } = require('ocad2geojson/src/ocad-to-geojson')
+const { ocadToGeoJson, ocadToSvg } = require('ocad2geojson')
 const sharp = require('sharp')
 const DOMImplementation = global.DOMImplementation
   ? global.DOMImplementation
@@ -7,18 +7,13 @@ const XMLSerializer = global.XMLSerializer
   ? global.XMLSerializer
   : require('xmldom').XMLSerializer
 
-module.exports = {
-  renderGeoJson,
-  renderSvg,
-  render,
-}
-
 function renderGeoJson(tiler, extent, options) {
   return ocadToGeoJson(tiler.ocadFile, {
     objects: tiler.getObjects(extent),
     ...options,
   })
 }
+
 
 function renderSvg(tiler, extent, resolution, options = {}) {
   const svg = tiler.renderSvg(extent, resolution, {
@@ -74,6 +69,89 @@ function render(tiler, extent, resolution, options = {}) {
   }
 }
 
+function renderFullSvg(tiler, extent, resolution, options = {}) {
+  const document = DOMImplementation.createDocument(null, 'xml', null)
+  const svg = ocadToSvg(tiler.ocadFile, {
+    objects: tiler.getObjects(extent, (options.buffer || 256) * resolution),
+    document,
+  })
+  fixIds(svg)
+  return svg
+}
+
+function renderFull(tiler, extent, resolution, options = {}) {
+  const crs = tiler.ocadFile.getCrs()
+  const svgResolution = Math.min(resolution, 1 * (crs.scale / 15000))
+  const svg = renderFullSvg(tiler, extent, svgResolution, options)
+  const extentWidth = extent[2] - extent[0]
+  const extentHeight = extent[3] - extent[1]
+
+  svg.setAttributeNS(
+    'http://www.w3.org/2000/svg',
+    'width',
+    extentWidth / svgResolution + 'px'
+  )
+  svg.setAttributeNS(
+    'http://www.w3.org/2000/svg',
+    'height',
+    extentHeight / svgResolution + 'px'
+  )
+  
+  const xml = new XMLSerializer().serializeToString(svg)
+  let result = sharp(Buffer.from(xml)).resize(
+    Math.round(extentWidth / resolution),
+    Math.round(extentHeight / resolution)
+  )
+  
+  if (options.applyGrivation) {
+    const alpha = (crs.grivation / Math.PI) * 180
+    result = result.rotate(alpha)
+  }
+
+  if (options.fill) {
+    result = result.flatten({ background: options.fill })
+  }
+  
+  if (options.outputPath) {
+    return result.toFile(options.outputPath)
+  } else if (options.format) {
+    return result.toFormat(options.format).toBuffer()
+  } else {
+    throw new Error('Missing option "outputPath" or "format".')
+  }
+}
+
+function render(tiler, extent, resolution, options = {}) {
+  const crs = tiler.ocadFile.getCrs()
+  const svgResolution = Math.min(resolution, 1 * (crs.scale / 15000))
+  const svg = renderSvg(tiler, extent, svgResolution, options)
+  const extentWidth = extent[2] - extent[0]
+  const extentHeight = extent[3] - extent[1]
+
+  svg.setAttributeNS(
+    'http://www.w3.org/2000/svg',
+    'width',
+    extentWidth / svgResolution + 'px'
+  )
+  svg.setAttributeNS(
+    'http://www.w3.org/2000/svg',
+    'height',
+    extentHeight / svgResolution + 'px'
+  )
+  const xml = new XMLSerializer().serializeToString(svg)
+  const result = sharp(Buffer.from(xml)).resize(
+    Math.round(extentWidth / resolution),
+    Math.round(extentHeight / resolution)
+  )
+  if (options.outputPath) {
+    return result.toFile(options.outputPath)
+  } else if (options.format) {
+    return result.toFormat(options.format).toBuffer()
+  } else {
+    throw new Error('Missing option "outputPath" or "format".')
+  }
+}
+
 // In xmldom, node ids are normal attributes, while in the browser's
 // DOM, they are a property on the node object itself. This method
 // recursively "fixes" nodes by adding id attributes.
@@ -86,4 +164,12 @@ function fixIds(n) {
       fixIds(n.childNodes[i])
     }
   }
+}
+
+module.exports = {
+  renderGeoJson,
+  renderSvg,
+  renderFullSvg,
+  render,
+  renderFull,
 }

--- a/src/ocad2image.js
+++ b/src/ocad2image.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const { program } = require('commander')
 const OcadTiler = require('ocad-tiler')
-const { render, renderSvg, renderGeoJson } = require('./')
+const { renderFull: render, renderFullSvg: renderSvg, renderGeoJson } = require('./')
 const { readOcad } = require('ocad2geojson')
 
 program
@@ -84,7 +84,9 @@ readOcad(ocadPath)
           process.exit(0)
         })
       } else {
-        fs.writeFileSync(outputPath, svg)
+        const XMLSerializer = require('xmldom').XMLSerializer
+        fs.writeFileSync(outputPath, new XMLSerializer().serializeToString(svg))
+        process.exit(0)
       }
     } else if (isGeoJson) {
       fs.writeFileSync(


### PR DESCRIPTION
Fix ocad2image with .svg output file that was broken.

Also now properly render images from OCAD samples.

Could not come up with same methods for tiles render and full image render without breaking one or the other...